### PR TITLE
Feat/ECO-2205 v5 source plugin changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "gatsby-plugin-robots-txt": "^1.8.0",
         "gatsby-plugin-sharp": "^5.0.0-next",
         "gatsby-plugin-sitemap": "^6.0.0",
-        "gatsby-source-contentstack": "^4.0.6",
+        "gatsby-source-contentstack": "^5.0.0",
         "gatsby-source-filesystem": "^5.0.0-next",
         "gatsby-transformer-sharp": "^5.0.0-next",
         "html-react-parser": "^1.4.4",
@@ -9316,9 +9316,9 @@
       }
     },
     "node_modules/gatsby-source-contentstack": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentstack/-/gatsby-source-contentstack-4.0.9.tgz",
-      "integrity": "sha512-SQ60u6KbkCLrHqQ3orwW1QayeRiDRhDU1hvQxRNM9zS3NZHJRdS5/1sPyXIyTm12I0Ieuq2UgbyLKuTQ79Nv6Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentstack/-/gatsby-source-contentstack-5.0.0.tgz",
+      "integrity": "sha512-UOph5x7/a50Goet+J+PdWx7zF3cJFeaJO+slvM7QE2mFUYDLTcFTfcocLV1ZRKcKfHBWDMAp8UEUX2wDMRt2kQ==",
       "dependencies": {
         "@contentstack/utils": "^1.1.1",
         "gatsby-core-utils": "^3.3.0",
@@ -9328,11 +9328,11 @@
         "query-string": "6.0.0"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "gatsby": "^3.0.0 || ^4.0.0",
-        "gatsby-plugin-image": "^2.0.0-next"
+        "gatsby": "^4.0.0 || ^5.0.0",
+        "gatsby-plugin-image": "^3.0.0-next"
       }
     },
     "node_modules/gatsby-source-contentstack/node_modules/gatsby-core-utils": {
@@ -24164,9 +24164,9 @@
       }
     },
     "gatsby-source-contentstack": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentstack/-/gatsby-source-contentstack-4.0.9.tgz",
-      "integrity": "sha512-SQ60u6KbkCLrHqQ3orwW1QayeRiDRhDU1hvQxRNM9zS3NZHJRdS5/1sPyXIyTm12I0Ieuq2UgbyLKuTQ79Nv6Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentstack/-/gatsby-source-contentstack-5.0.0.tgz",
+      "integrity": "sha512-UOph5x7/a50Goet+J+PdWx7zF3cJFeaJO+slvM7QE2mFUYDLTcFTfcocLV1ZRKcKfHBWDMAp8UEUX2wDMRt2kQ==",
       "requires": {
         "@contentstack/utils": "^1.1.1",
         "gatsby-core-utils": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gatsby-plugin-robots-txt": "^1.8.0",
     "gatsby-plugin-sharp": "^5.0.0-next",
     "gatsby-plugin-sitemap": "^6.0.0",
-    "gatsby-source-contentstack": "^4.0.6",
+    "gatsby-source-contentstack": "^5.0.0",
     "gatsby-source-filesystem": "^5.0.0-next",
     "gatsby-transformer-sharp": "^5.0.0-next",
     "html-react-parser": "^1.4.4",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19HQ5P5wl1M7knUTOzNPEJWgAcRlEKCYk%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=H2iP2mt)

Changes:

- Version bump of source plugin to v5
- package lock  & package json updates