### PR TITLE
fix:legacy issue for gatsby

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contentstack-gatsby-starter-app",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contentstack-gatsby-starter-app",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@contentstack/live-preview-utils": "^1.3.2",


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX198LRzEIbTKSAeS79ryW7gDiH2Ev1zz2E%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=P2HatsM)
Title- added legacy flag on npmrc